### PR TITLE
2025 09 19 01 fix typo in example

### DIFF
--- a/site/outdated/doc.ja/mail.html
+++ b/site/outdated/doc.ja/mail.html
@@ -582,7 +582,7 @@ pos: String<br>
 </p>
 <pre>
 # example
-mail['Content-Disposition'] = 'attachement; filename="test.rb"'
+mail['Content-Disposition'] = 'attachment; filename="test.rb"'
 p mail.disposition   # "attachment"
 </pre>
 

--- a/site/outdated/rdd/mail.rrd.m
+++ b/site/outdated/rdd/mail.rrd.m
@@ -504,7 +504,7 @@ e
 .
       --
       # example
-      mail['Content-Disposition'] = 'attachement; filename="test.rb"'
+      mail['Content-Disposition'] = 'attachment; filename="test.rb"'
       p mail.disposition   # "attachment"
       --
 

--- a/site/reference/mail.html
+++ b/site/reference/mail.html
@@ -511,7 +511,7 @@ If it does not exist, returns the DEFAULT.
 </p>
 <pre>
 # example
-mail['Content-Disposition'] = 'attachement; filename="test.rb"'
+mail['Content-Disposition'] = 'attachment; filename="test.rb"'
 p mail.disposition   # "attachment"
 </pre>
 


### PR DESCRIPTION
Fix typo in Content-Disposition value example. Should be "attachment" not "attachement". 